### PR TITLE
feat: detect outdated cryptographic algorithms

### DIFF
--- a/src/oss_sanitizer/config/patterns.py
+++ b/src/oss_sanitizer/config/patterns.py
@@ -25,6 +25,7 @@ class ScoringWeights:
     internal_url: float = 7.0
     internal_hostname: float = 6.0
     sensitive_algorithm: float = 8.0
+    outdated_crypto: float = 7.0
 
 
 @dataclass

--- a/src/oss_sanitizer/models.py
+++ b/src/oss_sanitizer/models.py
@@ -15,6 +15,7 @@ class FindingType(Enum):
     INTERNAL_URL = "internal_url"
     INTERNAL_HOSTNAME = "internal_hostname"
     SENSITIVE_ALGORITHM = "sensitive_algorithm"
+    OUTDATED_ALGORITHM = "outdated_algorithm"
 
 
 @dataclass

--- a/src/oss_sanitizer/scanner.py
+++ b/src/oss_sanitizer/scanner.py
@@ -10,7 +10,7 @@ import git
 from .config import Config
 from .models import Finding, ScanReport
 from .scanner_history import scan_git_history, should_skip, try_decode
-from .scanners import algorithms, dependencies, secrets, urls
+from .scanners import algorithms, dependencies, outdated_crypto, secrets, urls
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +56,7 @@ def _run_scanners(text: str, file_path: str, config: Config, commit_sha: str | N
         secrets.scan_for_secrets(text, file_path, config, commit_sha)
         + urls.scan_for_internal_references(text, file_path, config, commit_sha)
         + algorithms.scan_for_sensitive_algorithms(text, file_path, config, commit_sha)
+        + outdated_crypto.scan_for_outdated_crypto(text, file_path, config, commit_sha)
     )
 
 

--- a/src/oss_sanitizer/scanners/outdated_crypto.py
+++ b/src/oss_sanitizer/scanners/outdated_crypto.py
@@ -1,0 +1,181 @@
+"""Regex-based detection of outdated cryptographic algorithms."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from ..config import Config
+from ..models import Finding, FindingType
+
+_SKIP_FILENAMES = frozenset({
+    "package.json", "pom.xml", "build.gradle", "Makefile",
+    "Dockerfile", ".gitignore", "requirements.txt", "pyproject.toml",
+    "tsconfig.json", "webpack.config", ".eslintrc",
+})
+
+_AES = "AES-256-GCM"
+
+# Each entry: (compiled regex, algorithm label, suggested replacement)
+_RULES: list[tuple[re.Pattern[str], str, str]] = [
+    # DES — must not match 'des' inside longer words like 'deserialize', 'describe', 'desktop'
+    (
+        re.compile(
+            r'(?<![a-zA-Z])'
+            r'(?:DES\.new|DESKeySpec|DES/|"DES"'
+            r"|'des(?:-cbc|-ede|-ofb|-cfb)?'|des-cbc"
+            r')',
+            re.IGNORECASE,
+        ),
+        "DES",
+        _AES,
+    ),
+    # Triple-DES / 3DES / DESede
+    (
+        re.compile(
+            r'(?:'
+            r'DES3\.new|TripleDES|DESede'
+            r'|"DESede(?:/[^"]+)?"|"3DES"'
+            r"|'des3'|'des-ede3(?:-cbc|-ofb|-cfb)?'"
+            r'|3DES'
+            r')',
+            re.IGNORECASE,
+        ),
+        "3DES",
+        _AES,
+    ),
+    # RC4 / ARC4
+    (
+        re.compile(
+            r'(?:'
+            r'ARC4\.new|RC4\.new'
+            r"|\"RC4\"|'rc4'"
+            r'|SecretKeySpec\([^,]+,\s*"RC4"\)'
+            r')',
+            re.IGNORECASE,
+        ),
+        "RC4",
+        f"ChaCha20-Poly1305 or {_AES}",
+    ),
+    # RC2
+    (
+        re.compile(
+            r'(?:'
+            r"\"RC2\"|'rc2(?:-cbc|-ofb|-cfb)?'"
+            r'|SecretKeySpec\([^,]+,\s*"RC2"\)'
+            r')',
+            re.IGNORECASE,
+        ),
+        "RC2",
+        _AES,
+    ),
+    # MD5
+    (
+        re.compile(
+            r'(?:'
+            r'hashlib\.md5\b'
+            r'|MD5\.new\b'
+            r"|\"MD5\"|'md5'"
+            r'|md5\s*\('
+            r')',
+            re.IGNORECASE,
+        ),
+        "MD5",
+        "SHA-256 or bcrypt/argon2 for passwords",
+    ),
+    # SHA-1
+    (
+        re.compile(
+            r'(?:'
+            r'hashlib\.sha1\b'
+            r'|SHA1\.new\b'
+            r"|\"SHA-?1\"|'sha-?1'"
+            r')',
+            re.IGNORECASE,
+        ),
+        "SHA-1",
+        "SHA-256 or SHA-512",
+    ),
+    # Blowfish
+    (
+        re.compile(
+            r'(?:'
+            r'Blowfish\.new\b'
+            r'|"Blowfish"'
+            r"|'bf(?:-cbc|-ofb|-cfb)?'"
+            r'|SecretKeySpec\([^,]+,\s*"Blowfish"\)'
+            r')',
+            re.IGNORECASE,
+        ),
+        "Blowfish",
+        _AES,
+    ),
+]
+
+
+@dataclass
+class _FileCtx:
+    file_path: str
+    lines: list[str]
+    score: float
+    commit_sha: str | None
+
+
+@dataclass
+class _MatchCtx:
+    algo: str
+    replacement: str
+    file_path: str
+    line_number: int
+    line: str
+    score: float
+    commit_sha: str | None
+
+
+def _explanation(algo: str, replacement: str) -> str:
+    return (
+        f"{algo} is an outdated/deprecated cryptographic algorithm. "
+        f"Replace it with {replacement}, or inject the algorithm via environment "
+        f"configuration so it can be upgraded without code changes."
+    )
+
+
+def _make_finding(ctx: _MatchCtx) -> Finding:
+    return Finding(
+        finding_type=FindingType.OUTDATED_ALGORITHM,
+        description=f"Outdated cryptographic algorithm: {ctx.algo}",
+        file_path=ctx.file_path,
+        line_number=ctx.line_number,
+        score=ctx.score,
+        snippet=f"{ctx.line_number:>4} | {ctx.line}",
+        explanation=_explanation(ctx.algo, ctx.replacement),
+        commit_sha=ctx.commit_sha,
+    )
+
+
+def _scan_rule(fctx: _FileCtx, pattern: re.Pattern[str], algo: str, replacement: str) -> list[Finding]:
+    results = []
+    for lineno, line in enumerate(fctx.lines, start=1):
+        if pattern.search(line):
+            mctx = _MatchCtx(algo, replacement, fctx.file_path, lineno, line, fctx.score, fctx.commit_sha)
+            results.append(_make_finding(mctx))
+    return results
+
+
+def scan_for_outdated_crypto(
+    content: str,
+    file_path: str,
+    config: Config,
+    commit_sha: str | None = None,
+) -> list[Finding]:
+    """Detect usage of known outdated cryptographic algorithms via regex."""
+    if not config.scoring.outdated_crypto:
+        return []
+    if any(file_path.endswith(name) for name in _SKIP_FILENAMES):
+        return []
+
+    fctx = _FileCtx(file_path, content.splitlines(), config.scoring.outdated_crypto, commit_sha)
+    findings: list[Finding] = []
+    for pattern, algo, replacement in _RULES:
+        findings.extend(_scan_rule(fctx, pattern, algo, replacement))
+    return findings

--- a/tests/test_outdated_crypto.py
+++ b/tests/test_outdated_crypto.py
@@ -1,0 +1,245 @@
+"""Tests for the outdated cryptographic algorithm scanner."""
+
+from __future__ import annotations
+
+import pytest
+
+from oss_sanitizer.config import Config
+from oss_sanitizer.models import FindingType
+from oss_sanitizer.scanners.outdated_crypto import scan_for_outdated_crypto
+
+
+# ---------------------------------------------------------------------------
+# Skip conditions
+# ---------------------------------------------------------------------------
+
+
+def test_skipped_when_score_zero():
+    config = Config()
+    config.scoring.outdated_crypto = 0.0
+    findings = scan_for_outdated_crypto("DES.new(key)", "crypto.py", config)
+    assert findings == []
+
+
+def test_skipped_for_build_files():
+    config = Config()
+    for name in ["pom.xml", "package.json", "Dockerfile", "Makefile", "requirements.txt"]:
+        findings = scan_for_outdated_crypto("DES=deprecated", name, config)
+        assert findings == [], f"Should skip {name}"
+
+
+# ---------------------------------------------------------------------------
+# DES detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("snippet", [
+    'DES.new(key, DES.MODE_CBC)',               # Python pycryptodome
+    'Cipher.getInstance("DES")',               # Java
+    'Cipher.getInstance("DES/CBC/PKCS5Padding")',
+    "crypto.createCipher('des', key)",         # Node.js
+    "openssl_encrypt($data, 'des-cbc', $key)", # PHP
+    "new DESKeySpec(rawKey)",                  # Java key spec
+    'cipher = DES.new(key)',
+])
+def test_detects_des(snippet):
+    config = Config()
+    findings = scan_for_outdated_crypto(snippet, "cipher.py", config)
+    assert findings, f"Should detect DES in: {snippet!r}"
+    assert findings[0].finding_type == FindingType.OUTDATED_ALGORITHM
+
+
+# ---------------------------------------------------------------------------
+# Triple-DES detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("snippet", [
+    'DES3.new(key, DES3.MODE_CBC)',
+    'TripleDES.getInstance()',
+    'Cipher.getInstance("DESede")',
+    'Cipher.getInstance("DESede/CBC/PKCS5Padding")',
+    "crypto.createCipher('des3', key)",
+    "openssl_encrypt($d, 'des-ede3-cbc', $k)",
+    '3DES encryption used here',
+])
+def test_detects_triple_des(snippet):
+    config = Config()
+    findings = scan_for_outdated_crypto(snippet, "cipher.py", config)
+    assert findings, f"Should detect 3DES in: {snippet!r}"
+    assert findings[0].finding_type == FindingType.OUTDATED_ALGORITHM
+
+
+# ---------------------------------------------------------------------------
+# RC4 detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("snippet", [
+    'ARC4.new(key)',
+    'RC4.new(key)',
+    'Cipher.getInstance("RC4")',
+    "crypto.createCipher('rc4', key)",
+    'SecretKeySpec(key, "RC4")',
+])
+def test_detects_rc4(snippet):
+    config = Config()
+    findings = scan_for_outdated_crypto(snippet, "cipher.py", config)
+    assert findings, f"Should detect RC4 in: {snippet!r}"
+    assert findings[0].finding_type == FindingType.OUTDATED_ALGORITHM
+
+
+# ---------------------------------------------------------------------------
+# RC2 detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("snippet", [
+    'Cipher.getInstance("RC2")',
+    'SecretKeySpec(key, "RC2")',
+    "openssl_encrypt($d, 'rc2-cbc', $k)",
+])
+def test_detects_rc2(snippet):
+    config = Config()
+    findings = scan_for_outdated_crypto(snippet, "cipher.py", config)
+    assert findings, f"Should detect RC2 in: {snippet!r}"
+    assert findings[0].finding_type == FindingType.OUTDATED_ALGORITHM
+
+
+# ---------------------------------------------------------------------------
+# MD5 detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("snippet", [
+    'hashlib.md5(password)',
+    'MessageDigest.getInstance("MD5")',
+    'md5(password)',
+    'MD5.new(data)',
+    'crypto.createHash("md5")',
+    'hash("md5", $password)',
+])
+def test_detects_md5(snippet):
+    config = Config()
+    findings = scan_for_outdated_crypto(snippet, "auth.py", config)
+    assert findings, f"Should detect MD5 in: {snippet!r}"
+    assert findings[0].finding_type == FindingType.OUTDATED_ALGORITHM
+
+
+# ---------------------------------------------------------------------------
+# SHA-1 detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("snippet", [
+    'hashlib.sha1(password)',
+    'MessageDigest.getInstance("SHA-1")',
+    'MessageDigest.getInstance("SHA1")',
+    'SHA1.new(data)',
+    'crypto.createHash("sha1")',
+    'hash("sha1", $password)',
+])
+def test_detects_sha1(snippet):
+    config = Config()
+    findings = scan_for_outdated_crypto(snippet, "auth.py", config)
+    assert findings, f"Should detect SHA-1 in: {snippet!r}"
+    assert findings[0].finding_type == FindingType.OUTDATED_ALGORITHM
+
+
+# ---------------------------------------------------------------------------
+# Blowfish detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("snippet", [
+    'Cipher.getInstance("Blowfish")',
+    'Blowfish.new(key)',
+    'SecretKeySpec(key, "Blowfish")',
+    "openssl_encrypt($d, 'bf-cbc', $k)",
+])
+def test_detects_blowfish(snippet):
+    config = Config()
+    findings = scan_for_outdated_crypto(snippet, "cipher.py", config)
+    assert findings, f"Should detect Blowfish in: {snippet!r}"
+    assert findings[0].finding_type == FindingType.OUTDATED_ALGORITHM
+
+
+# ---------------------------------------------------------------------------
+# Finding metadata
+# ---------------------------------------------------------------------------
+
+
+def test_finding_has_correct_line_number():
+    config = Config()
+    content = "x = 1\ny = 2\nDES.new(key)\nz = 3"
+    findings = scan_for_outdated_crypto(content, "cipher.py", config)
+    assert findings[0].line_number == 3
+
+
+def test_finding_contains_snippet():
+    config = Config()
+    content = 'cipher = DES.new(key, DES.MODE_CBC)'
+    findings = scan_for_outdated_crypto(content, "cipher.py", config)
+    assert 'DES' in findings[0].snippet
+
+
+def test_finding_explanation_suggests_upgrade():
+    config = Config()
+    findings = scan_for_outdated_crypto('DES.new(key)', "cipher.py", config)
+    explanation = findings[0].explanation.lower()
+    assert "des" in explanation
+    assert any(word in explanation for word in ("outdated", "deprecated", "weak", "broken"))
+
+
+def test_finding_explanation_mentions_environment_injection():
+    config = Config()
+    findings = scan_for_outdated_crypto('DES.new(key)', "cipher.py", config)
+    explanation = findings[0].explanation.lower()
+    # Should mention injection or AES or modern alternative
+    assert any(word in explanation for word in ("inject", "aes", "modern", "replace", "environment"))
+
+
+def test_score_uses_config_weight():
+    config = Config()
+    config.scoring.outdated_crypto = 6.0
+    findings = scan_for_outdated_crypto('DES.new(key)', "cipher.py", config)
+    assert findings[0].score == 6.0
+
+
+def test_commit_sha_passed_through():
+    config = Config()
+    findings = scan_for_outdated_crypto('DES.new(key)', "cipher.py", config, commit_sha="abc123")
+    assert findings[0].commit_sha == "abc123"
+
+
+def test_multiple_algorithms_in_same_file():
+    config = Config()
+    content = "DES.new(key)\nhashlib.md5(password)\nRC4.new(key)"
+    findings = scan_for_outdated_crypto(content, "cipher.py", config)
+    assert len(findings) == 3
+
+
+def test_no_false_positive_for_aes():
+    config = Config()
+    findings = scan_for_outdated_crypto(
+        'AES.new(key, AES.MODE_GCM)\nSHA256.new(data)', "cipher.py", config
+    )
+    assert findings == []
+
+
+def test_no_false_positive_for_legitimate_comment():
+    """A comment mentioning DES in historical context should still be flagged."""
+    config = Config()
+    content = "# DES was broken in 1999 — we now use AES"
+    findings = scan_for_outdated_crypto(content, "notes.py", config)
+    # Comments mentioning DES are flagged — author should suppress if needed.
+    # This is intentional: the scanner is conservative (flags comments too).
+    assert len(findings) >= 0  # either outcome is acceptable; test documents the choice
+
+
+def test_no_false_positive_for_deserialization():
+    """'deserialize', 'describe', 'desktop' should NOT trigger DES detection."""
+    config = Config()
+    for word in ("deserialize(data)", "description = 'foo'", "desktop_path"):
+        findings = scan_for_outdated_crypto(word, "utils.py", config)
+        assert findings == [], f"False positive for: {word!r}"

--- a/tests/test_outdated_crypto.py
+++ b/tests/test_outdated_crypto.py
@@ -35,12 +35,13 @@ def test_skipped_for_build_files():
 
 @pytest.mark.parametrize("snippet", [
     'DES.new(key, DES.MODE_CBC)',               # Python pycryptodome
-    'Cipher.getInstance("DES")',               # Java
+    'Cipher.getInstance("DES")',               # Java inline
     'Cipher.getInstance("DES/CBC/PKCS5Padding")',
     "crypto.createCipher('des', key)",         # Node.js
     "openssl_encrypt($data, 'des-cbc', $key)", # PHP
     "new DESKeySpec(rawKey)",                  # Java key spec
     'cipher = DES.new(key)',
+    'ENCRYPTION_ALGORITHM = "DES"',            # constant declaration
 ])
 def test_detects_des(snippet):
     config = Config()
@@ -62,6 +63,7 @@ def test_detects_des(snippet):
     "crypto.createCipher('des3', key)",
     "openssl_encrypt($d, 'des-ede3-cbc', $k)",
     '3DES encryption used here',
+    'ENCRYPTION_ALGORITHM = "DESede"',         # constant declaration
 ])
 def test_detects_triple_des(snippet):
     config = Config()
@@ -81,6 +83,7 @@ def test_detects_triple_des(snippet):
     'Cipher.getInstance("RC4")',
     "crypto.createCipher('rc4', key)",
     'SecretKeySpec(key, "RC4")',
+    'STREAM_CIPHER = "RC4"',                   # constant declaration
 ])
 def test_detects_rc4(snippet):
     config = Config()
@@ -98,6 +101,7 @@ def test_detects_rc4(snippet):
     'Cipher.getInstance("RC2")',
     'SecretKeySpec(key, "RC2")',
     "openssl_encrypt($d, 'rc2-cbc', $k)",
+    'CIPHER_ALGO = "RC2"',                     # constant declaration
 ])
 def test_detects_rc2(snippet):
     config = Config()
@@ -118,6 +122,7 @@ def test_detects_rc2(snippet):
     'MD5.new(data)',
     'crypto.createHash("md5")',
     'hash("md5", $password)',
+    'HASH_ALGORITHM = "MD5"',                  # constant declaration
 ])
 def test_detects_md5(snippet):
     config = Config()
@@ -138,6 +143,7 @@ def test_detects_md5(snippet):
     'SHA1.new(data)',
     'crypto.createHash("sha1")',
     'hash("sha1", $password)',
+    'DIGEST_ALGORITHM = "SHA-1"',              # constant declaration
 ])
 def test_detects_sha1(snippet):
     config = Config()
@@ -156,6 +162,7 @@ def test_detects_sha1(snippet):
     'Blowfish.new(key)',
     'SecretKeySpec(key, "Blowfish")',
     "openssl_encrypt($d, 'bf-cbc', $k)",
+    'CIPHER_ALGO = "Blowfish"',                # constant declaration
 ])
 def test_detects_blowfish(snippet):
     config = Config()

--- a/tests/test_outdated_crypto.py
+++ b/tests/test_outdated_crypto.py
@@ -210,7 +210,7 @@ def test_score_uses_config_weight():
     config = Config()
     config.scoring.outdated_crypto = 6.0
     findings = scan_for_outdated_crypto('DES.new(key)', "cipher.py", config)
-    assert findings[0].score == 6.0
+    assert findings[0].score == pytest.approx(6.0)
 
 
 def test_commit_sha_passed_through():
@@ -234,14 +234,12 @@ def test_no_false_positive_for_aes():
     assert findings == []
 
 
-def test_no_false_positive_for_legitimate_comment():
-    """A comment mentioning DES in historical context should still be flagged."""
+def test_no_false_positive_for_historical_comment():
+    """Bare algorithm name in a comment (no API call context) is not flagged."""
     config = Config()
     content = "# DES was broken in 1999 — we now use AES"
     findings = scan_for_outdated_crypto(content, "notes.py", config)
-    # Comments mentioning DES are flagged — author should suppress if needed.
-    # This is intentional: the scanner is conservative (flags comments too).
-    assert len(findings) >= 0  # either outcome is acceptable; test documents the choice
+    assert findings == []
 
 
 def test_no_false_positive_for_deserialization():


### PR DESCRIPTION
Closes #3

## Summary

- Adds a regex-based scanner (`scanners/outdated_crypto.py`) that flags usage of known weak/deprecated cryptographic algorithms without requiring an LLM call
- Detects DES, 3DES, RC4, RC2, MD5, SHA-1, and Blowfish across Python, Java, Node.js, and PHP idioms
- Each finding names the algorithm, explains why it is deprecated, suggests a modern replacement (AES-256-GCM, SHA-256, ChaCha20-Poly1305, etc.), and recommends injecting the algorithm via environment configuration as a minimum remediation step
- Adds `FindingType.OUTDATED_ALGORITHM`, `ScoringWeights.outdated_crypto = 7.0`, and wires the scanner into the main orchestrator

## Test plan

- [ ] 50 new unit tests covering every algorithm, each language idiom, skip conditions, false-positive guards (`deserialize`, `describe`, `desktop`), line number accuracy, score/commit-sha propagation, and multi-match in one file
- [ ] 143 total tests pass (`uv run pytest`)
- [ ] `flake8` reports no violations on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)