### PR TITLE
feat: build Linux + Windows executables on every main push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,14 @@ name: Release
 on:
   push:
     tags: ["v*"]
+    branches: ["main"]
 
 permissions:
   contents: write
 
 jobs:
   test:
-    name: Test before release
+    name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -30,22 +31,87 @@ jobs:
       - name: Run tests
         run: uv run pytest
 
-  build-and-release:
-    name: Build wheel and publish release
-    runs-on: ubuntu-latest
+  build-executable:
+    name: Build executable (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     needs: test
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: oss-sanitizer-linux-x86_64
+          - os: windows-latest
+            artifact: oss-sanitizer-windows-x86_64.exe
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v4
 
-      - name: Build wheel and sdist
-        run: uv build
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Build executable
+        run: >
+          uv run pyinstaller
+          --onefile
+          --name ${{ matrix.artifact }}
+          --add-data "public_domains_allowlist.yaml:."
+          --add-data "src/oss_sanitizer/templates:oss_sanitizer/templates"
+          --hidden-import detect_secrets.plugins.artifactory
+          --hidden-import detect_secrets.plugins.aws
+          --hidden-import detect_secrets.plugins.azure_storage_key
+          --hidden-import detect_secrets.plugins.basic_auth
+          --hidden-import detect_secrets.plugins.github_token
+          --hidden-import detect_secrets.plugins.gitlab_token
+          --hidden-import detect_secrets.plugins.high_entropy_strings
+          --hidden-import detect_secrets.plugins.jwt
+          --hidden-import detect_secrets.plugins.keyword
+          --hidden-import detect_secrets.plugins.private_key
+          --hidden-import detect_secrets.plugins.slack
+          --hidden-import tldextract
+          --collect-data tldextract
+          src/oss_sanitizer/cli.py
+
+      - name: Smoke test
+        run: dist/${{ matrix.artifact }} --help
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/${{ matrix.artifact }}
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [test, build-executable]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo "tag=main-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*
+          tag_name: ${{ steps.version.outputs.tag }}
+          prerelease: ${{ steps.version.outputs.prerelease }}
           generate_release_notes: true
+          files: dist/**/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oss-sanitizer"
-version = "0.1.0"
+version = "0.2.0"
 description = "Source code compliance scanner for the Geneva Open Source Charter"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -35,6 +35,7 @@ dev = [
     "flake8-cognitive-complexity>=0.1",
     "wemake-python-styleguide>=0.19",
     "flake8-simplify>=0.21",
+    "pyinstaller>=6.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Closes #15

## Summary

- Release workflow now triggers on both `v*` tags (full release) and pushes to `main` (pre-release tagged `main-<short-SHA>`)
- PyInstaller build matrix: `ubuntu-latest` → `oss-sanitizer-linux-x86_64`, `windows-latest` → `oss-sanitizer-windows-x86_64.exe`
- Each binary is fully self-contained: Jinja2 templates, `public_domains_allowlist.yaml`, and all `detect-secrets` plugin hidden imports are bundled
- Smoke test (`--help`) runs on the built binary before it's uploaded
- Bumps version to `0.2.0`

## Test plan

- [x] Existing tests still run in `test` job (unchanged)
- [x] `build-executable` job runs PyInstaller on both Linux and Windows runners
- [x] Smoke test verifies binary starts correctly on each platform
- [x] Tagged pushes → full release; main pushes → pre-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)