### PR TITLE
fix: use wrapper entry point for PyInstaller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           --hidden-import detect_secrets.plugins.slack
           --hidden-import tldextract
           --collect-data tldextract
-          src/oss_sanitizer/cli.py
+          build_entry.py
 
       - name: Smoke test
         run: dist/${{ matrix.artifact }} --help

--- a/build_entry.py
+++ b/build_entry.py
@@ -1,0 +1,5 @@
+"""PyInstaller entry point — wraps the package CLI so relative imports work."""
+from oss_sanitizer.cli import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes the build failure in #19 / v0.2.1.

## Root cause

PyInstaller was pointed at `src/oss_sanitizer/cli.py` directly. Because the file uses relative imports (`from .cli_args import …`), PyInstaller treated it as a top-level script rather than a package module, producing:

```
ImportError: attempted relative import with no known parent package
```

## Fix

Add `build_entry.py` — a two-line wrapper that imports and calls the package entry point. PyInstaller builds from this wrapper; the `oss_sanitizer` package is discovered normally and all relative imports work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)